### PR TITLE
Ensure bridges are created before firewalls start

### DIFF
--- a/rc.d/vm
+++ b/rc.d/vm
@@ -4,7 +4,7 @@
 
 # PROVIDE: vm
 # REQUIRE: NETWORKING SERVERS dmesg
-# BEFORE: dnsmasq
+# BEFORE: dnsmasq ipfw pf
 # KEYWORD: shutdown nojail
 
 . /etc/rc.subr


### PR DESCRIPTION
Since the vm rc script can create bridges and since firewalls (like pf) may actually reference these bridges, make sure that the bridges are created before we start them. This makes the firewalls fail to start because an interface is missing.